### PR TITLE
Make print statements python3 compatible

### DIFF
--- a/testXGBoost.py
+++ b/testXGBoost.py
@@ -50,7 +50,7 @@ f = open(argv[3])
 # init count
 count = 0
 # print header
-print "Antibiotic\tMIC Test Method\tPrediction"#\tAverage W1 antibiotic\t95-conf low antibiotic\t95-conf high antibiotic\tNumber of Antibiotic Samples\tAvg	95-Conf Low\t95-Conf High\t95-Conf Size	Number of Samples"
+print("Antibiotic\tMIC_Test_Method\tPrediction")#\tAverage W1 antibiotic\t95-conf low antibiotic\t95-conf high antibiotic\tNumber of Antibiotic Samples\tAvg	95-Conf Low\t95-Conf High\t95-Conf Size	Number of Samples"
 # for each line in file
 # get keys for antibiotic statistics
 # search for antibiotic statistics
@@ -67,7 +67,7 @@ for i in f:
 	# except:
 	# 	stats = "prediction out of range"
 
-	print i + '\t' + str(2**pred[count])# + '\t' + stats
+	print(i + '\t' + str(2**pred[count]))# + '\t' + stats
 
 	count += 1
 


### PR DESCRIPTION
The module interfaces you use are the same in the py2 and py3 versions of xboost, your print statements are the only thing preventing py3 compatibility.


There's also a minor change to the output to make it more legible  (spaces replaced with '_' in the header)